### PR TITLE
Adding a local client password file provider

### DIFF
--- a/src/main/java/au/com/southsky/jfreesane/SaneClientAuthentication.java
+++ b/src/main/java/au/com/southsky/jfreesane/SaneClientAuthentication.java
@@ -1,0 +1,120 @@
+package au.com.southsky.jfreesane;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.StringTokenizer;
+
+import com.google.common.base.Predicate;
+import com.google.common.base.Strings;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Lists;
+import com.google.common.io.Files;
+
+public class SaneClientAuthentication {
+	public static final String MARKER_MD5 = "$MD5$";
+
+	private static final String DEFAULT_CONFIGURATION_PATH = String.format("%s%s%s%s%s",System.getProperty("user.home"),File.separator,".sane",File.separator,"pass");
+	
+	protected List<ClientCredential>credentials;
+	
+	public SaneClientAuthentication() {
+		this(DEFAULT_CONFIGURATION_PATH);
+	}
+	
+	public SaneClientAuthentication(String configurationPath) {
+		if ( Strings.isNullOrEmpty(configurationPath) ) {
+			return;
+		}
+		credentials = initialise(new File(configurationPath));
+	}
+	
+	protected List<ClientCredential> initialise(File configurationFile) {
+		List<ClientCredential>credentials = Lists.newArrayList();
+		if ( configurationFile == null || (! configurationFile.exists()) || (!configurationFile.canRead() ) ) {
+			return credentials;
+		}
+		List<String>lines = Lists.newArrayList();
+		try {
+			lines = Files.readLines(configurationFile, Charset.defaultCharset());
+		} catch (Exception x) {			
+		}
+		for(String line : lines) {
+			credentials.add( ClientCredential.fromAuthString(line) );
+		}
+	
+		return credentials;
+	}
+	
+	
+	public boolean canAuthenticate(String rc) {
+		return canAuthenticate(rc,credentials);
+	}
+	
+	protected boolean canAuthenticate(String rc, List<ClientCredential> credentialList) {
+		return getCredentialsForResource(rc,credentialList).size() == 1;
+	}
+	
+	
+	public List<ClientCredential> getCredentialsForResource(String rc) {
+		return getCredentialsForResource(rc, credentials);
+	}
+	
+	protected List<ClientCredential> getCredentialsForResource(String rc, List<ClientCredential> credentialList) {
+		List<ClientCredential>results = Lists.newArrayList();
+		if ( ! Strings.isNullOrEmpty(rc) ) {
+			String resource = rc.contains( MARKER_MD5 ) ? rc.substring(0, rc.indexOf(MARKER_MD5)) : rc;
+			results.addAll(Collections2.filter(credentialList, ClientCredential.BackendFilter.forBackend(resource)));
+		}
+		
+		if ( results.size() > 1 ) {
+			System.out.println(String.format("Warning: multiple authentication lines for backend %s",rc));
+		}
+		return results;
+	}
+	
+	/** Class to hold Sane client credentials organised by backend
+	 * 
+	 * @author paul
+	 *
+	 */
+	public static class ClientCredential {
+		public final String backend;
+		public final String username;
+		public final String password;
+		
+		protected ClientCredential(String backend,String username, String password) {
+			this.backend = backend;
+			this.username = username;
+			this.password = password;
+		}
+		
+		public static ClientCredential fromAuthString(String authString) {
+			StringTokenizer t = new StringTokenizer(authString,":");
+			String backend = t.hasMoreTokens() ? t.nextToken() : "";
+			String username = t.hasMoreTokens() ? t.nextToken() : "";
+			String password = t.hasMoreTokens() ? t.nextToken() : "";
+			ClientCredential cc = new ClientCredential(backend,username,password);
+			return cc;
+		}
+		
+		static class BackendFilter implements Predicate<ClientCredential> {
+			private String backend;
+			private BackendFilter(String backend) {
+				this.backend = backend;
+			}
+			
+			static BackendFilter forBackend(String backend) {
+				return new BackendFilter(backend);
+			}
+			
+			@Override
+			public boolean apply(ClientCredential credential) {
+				if ( Strings.isNullOrEmpty(backend) || credential == null || Strings.isNullOrEmpty(credential.backend) ) {
+					return false;
+				}
+				return credential.backend.equalsIgnoreCase(backend);
+			}
+		}
+	}
+}

--- a/src/main/java/au/com/southsky/jfreesane/SanePasswordProvider.java
+++ b/src/main/java/au/com/southsky/jfreesane/SanePasswordProvider.java
@@ -16,6 +16,10 @@
 
 package au.com.southsky.jfreesane;
 
+import au.com.southsky.jfreesane.SaneClientAuthentication.ClientCredential;
+
+import com.google.common.base.Strings;
+
 /**
  * Implements a provider of SANE resource credentials. If the SANE server asks
  * JFreeSane to provide a password, the {@link SaneSession} will consult its
@@ -42,5 +46,32 @@ public abstract class SanePasswordProvider {
         return password;
       }
     };
+  }
+  
+  public static SanePasswordProvider forResource(final String resource) {
+	  return forResource(resource,null);
+  }
+  
+  public static SanePasswordProvider forResource(final String resource, String passwordFile) {
+	  SaneClientAuthentication sca = Strings.isNullOrEmpty(passwordFile) ? new SaneClientAuthentication() : new SaneClientAuthentication(passwordFile);
+	  if ( ! sca.canAuthenticate(resource) ) {
+		  return null;
+	  }
+	  final ClientCredential credential = sca.getCredentialsForResource(resource).iterator().next();
+	  
+	  return new SanePasswordProvider() {
+		@Override
+		public String getUsername() {
+			// TODO Auto-generated method stub
+			return credential.username;
+		}
+
+		@Override
+		public String getPassword() {
+			// TODO Auto-generated method stub
+			return credential.password;
+		}
+		  
+	  };
   }
 }

--- a/src/test/java/au/com/southsky/jfreesane/SaneClientAuthenticationTest.java
+++ b/src/test/java/au/com/southsky/jfreesane/SaneClientAuthenticationTest.java
@@ -1,0 +1,119 @@
+package au.com.southsky.jfreesane;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.UUID;
+
+import junit.framework.Assert;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import au.com.southsky.jfreesane.SaneClientAuthentication.ClientCredential;
+
+import com.google.common.io.Files;
+
+public class SaneClientAuthenticationTest {
+
+	private File testusers;
+	private final String NL = String.format("%n");
+	
+	@Before
+	public void onSetup() throws IOException {
+		testusers = createTempFile();
+	}
+	
+	@After
+	public void tearDown() {
+		testusers.delete();
+	}
+	
+	@Test
+	public void testSaneClientAuthentication() {
+		SaneClientAuthentication sca = new SaneClientAuthentication();
+		Assert.assertNotNull(sca);
+	}
+
+	@Test
+	public void testSaneClientAuthenticationWithMissingFileDoesNotFail() {
+		String filepath = "NONE_EXISTENT_PATH_"+UUID.randomUUID().toString();
+		SaneClientAuthentication sca = new SaneClientAuthentication(filepath);
+		Assert.assertNotNull(sca);
+	}
+	
+	@Test
+	public void testSaneClientAuthenticationWithTempFileSucceeds() {
+		SaneClientAuthentication sca = new SaneClientAuthentication(testusers.getPath());
+		Assert.assertNotNull(sca);
+		Assert.assertEquals(3, sca.credentials.size());
+	}
+
+	@Test
+	public void testInitialise() throws IOException {
+		List<ClientCredential>credentials = null;
+		SaneClientAuthentication sca = new SaneClientAuthentication();
+		credentials = sca.initialise(testusers);
+		Assert.assertNotNull(credentials);
+		Assert.assertEquals(3,  credentials.size());
+		Assert.assertEquals("pixma", credentials.get(0).backend);
+		Assert.assertEquals("net", credentials.get(1).backend);
+		Assert.assertEquals("mustek", credentials.get(2).backend);
+		
+		Assert.assertEquals("sane-user", credentials.get(0).username);
+		Assert.assertEquals("other-user", credentials.get(1).username);
+		Assert.assertEquals("user", credentials.get(2).username);
+		
+		Assert.assertEquals("password", credentials.get(0).password);
+		Assert.assertEquals("strongPassword", credentials.get(1).password);
+		Assert.assertEquals("", credentials.get(2).password);
+	}
+
+	@Test
+	public void testCanAuthenticateNullResourceFailure() {
+		SaneClientAuthentication sca = new SaneClientAuthentication();
+		Assert.assertFalse(sca.canAuthenticate(null));
+	}
+	
+	@Test
+	public void testCanAuthenticateFalse() {
+		String rcString = "missing$MD5$iamarandomstring";
+		SaneClientAuthentication sca = new SaneClientAuthentication(testusers.getPath());
+		Assert.assertFalse(sca.canAuthenticate(rcString));
+	}
+	
+	@Test
+	public void testCanAuthenticateTrue() {
+		String rcString = "pixma$MD5$iamarandomstring";
+		SaneClientAuthentication sca = new SaneClientAuthentication(testusers.getPath());
+		Assert.assertTrue(sca.canAuthenticate(rcString));
+	}
+	
+	@Test
+	public void testCanAuthenticateTrueWithoutMD5() {
+		String rcString = "mustek";
+		SaneClientAuthentication sca = new SaneClientAuthentication(testusers.getPath());
+		Assert.assertTrue(sca.canAuthenticate(rcString));
+	}
+	
+	@Test
+	public void testCanAuthenticateFailTooManyBackends() {
+		String rcString = "pixma";
+		SaneClientAuthentication sca = new SaneClientAuthentication(testusers.getPath());
+		sca.credentials.add( new SaneClientAuthentication.ClientCredential("pixma","second-user","password"));
+		Assert.assertFalse( sca.canAuthenticate(rcString));
+	}
+
+	private File createTempFile() throws IOException {
+		StringBuffer users = new StringBuffer();
+		users.append("pixma:sane-user:password").append(NL);
+		users.append("net:other-user:strongPassword").append(NL);
+		users.append("mustek:user:").append(NL);
+		File testfile = File.createTempFile("sanepass", null);
+		Files.write(users.toString(), testfile, Charset.defaultCharset());
+		return testfile;
+	}
+}
+

--- a/src/test/java/au/com/southsky/jfreesane/SaneSessionTest.java
+++ b/src/test/java/au/com/southsky/jfreesane/SaneSessionTest.java
@@ -520,7 +520,23 @@ public class SaneSessionTest {
     device.open();
     device.acquireImage();
   }
+  
+  @Test
+  public void passwordAuthenticationFromLocalFile() throws Exception {
+    session.setPasswordProvider(SanePasswordProvider.forResource("pixma"));
+    SaneDevice device = session.getDevice("pixma");
+    device.open();
+    device.acquireImage();
+  }
 
+  @Test
+  public void passwordAuthenticationFromLocalFileSpecified() throws Exception {
+	    session.setPasswordProvider(SanePasswordProvider.forResource("pixma","/tmp/sane.pass"));
+	    SaneDevice device = session.getDevice("pixma");
+	    device.open();
+	    device.acquireImage();
+	  }
+  
   private void openAndCloseDevice(SaneDevice device) throws Exception {
     try {
       device.open();


### PR DESCRIPTION
Hi - just adding a SanePasswordProvider anonymous provider to allow usage of local ~/.sane/pass files  (as used by scanimage) for authentication
