### PR TITLE
Remove cancelDevice from acquireImage().

### DIFF
--- a/src/main/java/au/com/southsky/jfreesane/SaneSession.java
+++ b/src/main/java/au/com/southsky/jfreesane/SaneSession.java
@@ -178,8 +178,6 @@ public class SaneSession implements Closeable {
       }
     } while (!parameters.isLastFrame());
 
-    cancelDevice(handle);
-
     SaneImage image = builder.build();
     return image.toBufferedImage();
   }


### PR DESCRIPTION
This call needs to be made after the user is finished acquiring images, not after each image.
