### PR TITLE
Fix a bug in acquireImage exception handling.

### DIFF
--- a/src/main/java/au/com/southsky/jfreesane/SaneSession.java
+++ b/src/main/java/au/com/southsky/jfreesane/SaneSession.java
@@ -128,16 +128,15 @@ public class SaneSession implements Closeable {
       outputStream.write(SaneRpcCode.SANE_NET_START);
       outputStream.write(handle.getHandle());
 
-      {
-        int status = inputStream.readWord().integerValue();
-        if (status != 0) {
-          throw new SaneException(SaneStatus.fromWireValue(status));
-        }
-      }
+      SaneWord startStatus = inputStream.readWord();
 
       int port = inputStream.readWord().integerValue();
       SaneWord byteOrder = inputStream.readWord();
       String resource = inputStream.readString();
+
+      if (startStatus.integerValue() != 0) {
+        throw SaneException.fromStatusWord(startStatus);
+      }
 
       if (!resource.isEmpty()) {
         authorize(resource);


### PR DESCRIPTION
Previously, a non-zero status to SANE_NET_START would cause JFreeSane to throw
an exception as soon as the bad status was read from the input stream. The
remaining bytes of SANE's response to the SANE_NET_START would remain on the
stream, leaving JFreeSane in the wrong state to begin handling subsequent
requests.

This was particularly evident in situations where you expect a non-zero scan
result, e.g. in ADF scanning (where the last page will return a STATUS_NO_DOCS
error).
