### PR TITLE
Improve performance on consecutive write() calls.

### DIFF
--- a/src/main/java/au/com/southsky/jfreesane/SaneSession.java
+++ b/src/main/java/au/com/southsky/jfreesane/SaneSession.java
@@ -32,6 +32,7 @@ public class SaneSession implements Closeable {
 
   private SaneSession(Socket socket) throws IOException {
     this.socket = socket;
+    this.socket.setTcpNoDelay(true);
     this.outputStream = new SaneOutputStream(socket.getOutputStream());
     this.inputStream = new SaneInputStream(this, socket.getInputStream());
   }


### PR DESCRIPTION
Hi,

Add tcp_no_delay on client socket improve network performance throughput between jfreesane client and sane.d server !

Cheers,
Jérôme.