### PR TITLE
set relativePath to empty string because it ought to be resolved from…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.sonatype.oss</groupId>
+    <artifactId>oss-parent</artifactId>
+    <version>7</version>
+    <relativePath></relativePath>
+  </parent>
   <groupId>com.googlecode.jfreesane</groupId>
   <artifactId>jfreesane</artifactId>
   <packaging>jar</packaging>
@@ -32,11 +38,6 @@
       <email>smr@southsky.com.au</email>
     </developer>
   </developers>
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
-  </parent>
   <distributionManagement>
     <repository>
       <id>sonatype-nexus-staging</id>


### PR DESCRIPTION
… repositories in order to avoid maven warnings; moved parent element to the top so that it's more visible