### PR TITLE
ignoring not writeable options to solve fujitsu backend duplicate opt…

### DIFF
--- a/src/main/java/au/com/southsky/jfreesane/SaneOption.java
+++ b/src/main/java/au/com/southsky/jfreesane/SaneOption.java
@@ -199,6 +199,13 @@ public final class SaneOption {
           continue;
         }
 
+        if (!option.isWriteable()) {
+          //as it is done into scanimage, we ignore !SANE_OPTION_IS_SETTABLE options
+          //this solve problems with pfufs backend (fujitsu scanner) which returns several not settable options with the name 'inactive'
+          logger.fine(String.format("ignoring not writeable option with id %d: %s", i, option));
+          continue;
+        }
+
         options.add(option);
       }
     }


### PR DESCRIPTION
…ions

This is what is done by scanimage (fetch_options function)
pfufs backend (fujutsu scanner) returns all options which have not the
SANE_CAP_SOFT_SELECT capability with the same name 'inactive'.