### PR TITLE
Pass connection and read timeouts to image data socket.

### DIFF
--- a/src/test/java/au/com/southsky/jfreesane/ImageAcquisitionTest.java
+++ b/src/test/java/au/com/southsky/jfreesane/ImageAcquisitionTest.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 
@@ -41,7 +42,11 @@ public class ImageAcquisitionTest {
     this.session =
         SaneSession.withRemoteSane(
             InetAddress.getByName(hostAndPort.getHost()),
-            hostAndPort.getPort() == -1 ? 6566 : hostAndPort.getPort());
+            hostAndPort.getPort() == -1 ? 6566 : hostAndPort.getPort(),
+            20,
+            TimeUnit.SECONDS,
+            20,
+            TimeUnit.SECONDS);
     session.setPasswordProvider(correctPasswordProvider);
   }
 


### PR DESCRIPTION
SANE uses separate connections for control and image data. Currently,
the control socket uses connection and read timeouts that can be
specified by the user in the `SaneSession.withRemoteSane` methods. The
image data socket uses no timeouts whatsoever. This can cause infinite
delays in the case of network issues.

This change passes the user-specified connection and read timeouts to
the data socket.