### PR TITLE
Use jacoco for code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
 
 script: ./gradlew check --info
 
-after_success: ./gradlew cobertura coveralls
+after_success: ./gradlew jacocoTestReport coveralls
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/build.gradle
+++ b/build.gradle
@@ -8,11 +8,16 @@ plugins {
     id 'net.ltgt.errorprone' version '1.1.1'
 
     // code coverage support
-    id 'net.saliman.cobertura' version '3.0.0'
-    id 'com.github.kt3k.coveralls' version '2.8.2'
+    id 'jacoco'
+    id 'com.github.kt3k.coveralls' version '2.8.4'
 }
 
-cobertura.coverageFormats = ['html', 'xml']
+jacocoTestReport {
+    reports {
+        xml.enabled = true // coveralls plugin depends on xml format report
+        html.enabled = true
+    }
+}
 
 def releaseVersion = '0.98'
 


### PR DESCRIPTION
Cobertura supports invokespecial at head, but it hasn't had a release in
years. JaCoCo on the other hand is still being released relatively
frequently.