### PR TITLE
Fix listDevices() interfering with subsequent operations

### DIFF
--- a/src/main/java/au/com/southsky/jfreesane/SaneInputStream.java
+++ b/src/main/java/au/com/southsky/jfreesane/SaneInputStream.java
@@ -55,6 +55,9 @@ class SaneInputStream extends InputStream {
     int length = readWord().integerValue() - 1;
 
     if (length <= 0) {
+      // remove leftover word from stream to prevent it from breaking
+      // the following operation in this session
+      readWord();
       return new ArrayList<>(0);
     }
 

--- a/src/test/java/au/com/southsky/jfreesane/SaneSessionTest.java
+++ b/src/test/java/au/com/southsky/jfreesane/SaneSessionTest.java
@@ -3,7 +3,6 @@ package au.com.southsky.jfreesane;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/src/test/java/au/com/southsky/jfreesane/SaneSessionTest.java
+++ b/src/test/java/au/com/southsky/jfreesane/SaneSessionTest.java
@@ -377,7 +377,6 @@ public class SaneSessionTest {
   }
 
   @Test
-  @Ignore // This test fails on Travis with UNSUPPORTED.
   public void multipleListDevicesCalls() throws Exception {
     session.listDevices();
     session.listDevices();


### PR DESCRIPTION
Executing readWord() also in empty deviceList cases. This fixes the issue with subsequent operations failing due to the leftover word in the stream. 
#100 