### PR TITLE
Ensure the stream is correctly positioned after an error

### DIFF
--- a/src/test/java/au/com/southsky/jfreesane/SaneSessionTest.java
+++ b/src/test/java/au/com/southsky/jfreesane/SaneSessionTest.java
@@ -26,6 +26,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests JFreeSane's interactions with the backend.
@@ -523,6 +524,21 @@ public class SaneSessionTest {
     assertThat(notifiedDevice.get()).isSameAs(device);
     assertThat(frameCount.get()).isEqualTo(3);
     assertThat(framesSeen).containsExactly(FrameType.RED, FrameType.GREEN, FrameType.BLUE);
+  }
+
+  @Test
+  public void canSetOptionAfterFailingToSet() throws Exception {
+    SaneDevice device = saneDaemon.getSession().getDevice("test");
+    device.open();
+    try {
+      device.getOption("mode").setStringValue("Gray ");
+      fail("expected SaneException, but none was thrown");
+    } catch (SaneException e) {
+      // expected
+    }
+
+    // The SANE session stream should be placed in a good state for another try. This should not throw.
+    assertThat(device.getOption("mode").setStringValue("Gray")).isEqualTo("Gray");
   }
 
   private void openAndCloseDevice(SaneDevice device) throws Exception {


### PR DESCRIPTION
Currently, in SANE_NET_CONTROL_OPTION we throw an exception immediately after reading a non-zero response status. This puts the stream in a bad state, with many bytes of unread responses confusing future calls.

This change reads off all bytes irrespective of the status message. An exception is finally thrown when the stream is positioned appropriately.